### PR TITLE
Add ssl config option to force SSL/TLS

### DIFF
--- a/mqtt-config-schema.coffee
+++ b/mqtt-config-schema.coffee
@@ -81,4 +81,8 @@ module.exports = {
             description: "Path to the trusted CA list"
             type: "string"
             default: ""
+          ssl:
+            description: "Force the use of TLS/SSL"
+            type: "boolean"
+            default: false
 }

--- a/mqtt.coffee
+++ b/mqtt.coffee
@@ -72,7 +72,7 @@ module.exports = (env) ->
           debug: @config.debug
         )
 
-        if brokerConfig.ca or brokerConfig.certPath or brokerConfig.keyPath
+        if brokerConfig.ca or brokerConfig.certPath or brokerConfig.keyPath or brokerConfig.ssl
           options.protocol = 'mqtts'
 
         mqttClient = null


### PR DESCRIPTION
This PR adds an option to the broker configuration `ssl:boolean`.

When `ssl` is set to `true`, SSL/TLS will be enabled like before when using a CA/Cert/Key. This allows one to enable SSL/TLS without having to specifically specifying the CA/Cert/Key, which I think is useful.

The Cert/Key are only used for client side authentication.
Configuring a CA would be more secure, but also requires more maintenance, because you might have to update it when the server changes its certificate. For most scenarios is safe enough to relay on the system wide trusted CAs, which is the default when using SSL/TLS without an explicit CA.