### PR TITLE
Support autoReset in MqttPresenceSensor

### DIFF
--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -132,6 +132,14 @@ module.exports = {
     extensions: ["xLink", "xPresentLabel", "xAbsentLabel"]
     required: ["topic"]
     properties:
+      autoReset:
+        description: """Reset the state to absent after resetTime"""
+        type: "boolean"
+        default: true
+      resetTime:
+        description: "Time after that the presence value is reseted to absent."
+        type: "integer"
+        default: 10000
       brokerId:
         description: "Id of the broker"
         type: "string"


### PR DESCRIPTION
This PR adds support for `autoReset` with a configurable delay to the MqttPresenceSensor. It should behave just like the `autoReset` in the DummyPresenceSensor.

Back story; last week when I went on a holiday the device hosting my MQTT presence sensor was turned off and the last state reported was 'present' so my Pimatic behaved as if we were present during the whole holiday... The `autoReset` will helpt prevent this scenario in the future.