### PR TITLE
Minor fixes on auto reset presence

### DIFF
--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -153,9 +153,11 @@ module.exports = {
         default: 0
         enum: [0, 1, 2]
       autoReset:
+        description: "Reset the state to absent after resetTime"
         type: "boolean"
         default: false
       resetTime:
+        description: "Time (in ms) after which the presence value is reseted to absent."
         type: "integer"
         default: 30000
   }

--- a/devices/mqtt-presence-sensor.coffee
+++ b/devices/mqtt-presence-sensor.coffee
@@ -26,9 +26,6 @@ module.exports = (env) ->
 
       @mqttclient.on('message', (topic, message) =>
         if @config.topic == topic
-          clearTimeout(@_resetPresenceTimeout)
-          if @config.autoReset is true
-            @_resetPresenceTimeout = setTimeout(resetPresence, @config.resetTime)
           switch message.toString()
             when @config.onMessage
                @_setPresence(yes)
@@ -36,6 +33,9 @@ module.exports = (env) ->
                @_setPresence(no)
             else
               env.logger.debug "#{@name} with id:#{@id}: Message is not harmony with onMessage or offMessage in config.json or with default values"
+          clearTimeout(@_resetPresenceTimeout)
+          if @config.autoReset and @_presence
+            @_resetPresenceTimeout = setTimeout(resetPresence, @config.resetTime)
         )
       super()
 

--- a/devices/mqtt-presence-sensor.coffee
+++ b/devices/mqtt-presence-sensor.coffee
@@ -16,12 +16,11 @@ module.exports = (env) ->
       if @mqttclient.connected
         @onConnect()
 
+      if @config.autoReset and @_presence
+        @_resetPresenceTimeout = setTimeout(@resetPresence, @config.resetTime)
+
       @mqttclient.on('connect', =>
         @onConnect()
-      )
-
-      resetPresence = ( =>
-        @_setPresence(no)
       )
 
       @mqttclient.on('message', (topic, message) =>
@@ -35,7 +34,7 @@ module.exports = (env) ->
               env.logger.debug "#{@name} with id:#{@id}: Message is not harmony with onMessage or offMessage in config.json or with default values"
           clearTimeout(@_resetPresenceTimeout)
           if @config.autoReset and @_presence
-            @_resetPresenceTimeout = setTimeout(resetPresence, @config.resetTime)
+            @_resetPresenceTimeout = setTimeout(@resetPresence, @config.resetTime)
         )
       super()
 
@@ -43,6 +42,9 @@ module.exports = (env) ->
       @mqttclient.subscribe(@config.topic, { qos: @config.qos })
 
     getPresence: () -> Promise.resolve(@_presence)
+
+    resetPresence: () =>
+      @_setPresence(no)
 
     destroy: () ->
      @mqttclient.unsubscribe(@config.topic)


### PR DESCRIPTION
As discussed in #39, this PR is for master.

This PR fixes some minor details in the #35 PR that had been addressed in #36:
* Trigger at boot - the presence is now also reset if pimatic was stopped while the sensor reported present and then started again later
* Only reset if present - like the original code, only trigger a resent to absent if the message received reported presence to prevent double events reporting absence
* Add description to vars - help people understand the configuration options