### PR TITLE
Added predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ The Button Action Provider
 
 * press [the] device
 
-##Rules
+## Rules
 
 You can publish mqtt messages in rules with the action:
 
@@ -448,6 +448,20 @@ You can publish mqtt messages in rules with the action:
         "active": true,
         "logging": false,
         "name": "Publish mqtt"
+      }
+    ]
+
+You can trigger rules by mqtt messages with the predicate:
+
+`mqtt received "<message>" on topic "<topic>" [via broker ListOfBrokers] [qos: 0|1|2]`
+
+    "rules": [
+      {
+        "id": "my-rule-2",
+        "name": "Receive mqtt",
+        "rule": "when mqtt received \"1\" on topic \"topic\" via broker default qos: 0 then log \"Yeah!\"",
+        "active": true,
+        "logging": true
       }
     ]
 

--- a/mqtt.coffee
+++ b/mqtt.coffee
@@ -22,6 +22,7 @@ module.exports = (env) ->
 
   # import preadicares and actions
   MqttActionProvider = require('./predicates_and_actions/mqtt_action')(env)
+  MqttPredicateProvider = require('./predicates_and_actions/mqtt_predicate')(env)
 
   # Pimatic MQTT Plugin class
   class MqttPlugin extends env.plugins.Plugin
@@ -119,6 +120,7 @@ module.exports = (env) ->
         })
 
       @framework.ruleManager.addActionProvider(new MqttActionProvider(@framework, @))
+      @framework.ruleManager.addPredicateProvider(new MqttPredicateProvider(@framework, @))
 
     callbackHandler: (className, classType) ->
       # this closure is required to keep the className and classType context as part of the iteration

--- a/predicates_and_actions/mqtt_predicate.coffee
+++ b/predicates_and_actions/mqtt_predicate.coffee
@@ -1,0 +1,88 @@
+module.exports = (env) ->
+
+  Promise = env.require 'bluebird'
+  M = env.matcher
+
+  class MqttPredicateProvider extends env.predicates.PredicateProvider
+    constructor: (@framework, @plugin) ->
+
+    parsePredicate: (input, context) ->
+
+      brokersId = []
+      for id of @plugin.brokers
+        brokersId.push id
+
+      message = null
+      topic = null
+      brokerId = "default"
+      qos = "0"
+
+      m = M(input, context)
+        .match("mqtt received ")
+        .matchString( (m,expr) =>
+          message = expr
+        )
+        .match(" on topic ")
+        .matchString( (m,expr) =>
+          topic = expr
+        )
+        .optional( (m) =>
+          next = m
+          m.match(" via broker ")
+          .match(brokersId , (m, expr) =>
+            brokerId = expr
+          )
+        )
+        .optional( (m) =>
+          next = m
+          m.match(" qos: ")
+          .match(["0","1","2"], (m, expr) =>
+            next = m
+            qos = parseInt expr
+          )
+          return next
+        )
+
+      if m.hadMatch()
+        match = m.getFullMatch()
+        return {
+          token: match
+          nextInput: input.substring(match.length)
+          predicateHandler: new MqttPredicateHandler(@framework, @plugin, brokerId, topic, message, qos)
+        }
+      else
+        return null
+
+  class MqttPredicateHandler extends env.predicates.PredicateHandler
+    constructor: (@framework, @plugin, @brokerId, @topic, @message, @qos) ->
+      @mqttclient = @plugin.brokers[@brokerId].client
+      super()
+
+    setup: ->
+      env.logger.debug "PredicateHandler", @brokerId, @topic, @message
+
+      # handle received messages
+      @mqttclient.on('message', @recvListener = (topic, message) =>
+        message = message.toString()
+        # check topic
+        return if topic isnt @topic
+
+        # check message
+        return if message isnt @message and @message isnt "*"
+
+        @emit 'change', 'event'
+      )
+
+      @mqttclient.subscribe @topic, { qos: @qos }
+
+      super()
+
+    destroy: ->
+      @mqttclient.removeListener 'received', @recvListener
+      @mqttclient.unsubscribe @topic
+      super()
+
+    getValue: -> Promise.resolve false
+    getType: -> 'event'
+
+  return MqttPredicateProvider


### PR DESCRIPTION
This PR adds predicates to trigger rules by a received mqtt message.

Example:
`mqtt received "<message>" on topic "<topic>" [via broker ListOfBrokers] [qos: 0|1|2]`

```
    "rules": [
      {
        "id": "my-rule-2",
        "name": "Receive mqtt",
        "rule": "when mqtt received \"1\" on topic \"topic\" via broker default qos: 0 then log \"Yeah!\"",
        "active": true,
        "logging": true
      }
    ]
```